### PR TITLE
Changes to allow for switching the redis DB

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,6 +39,8 @@ redisClient.on('error', function (error) {
   logger.log('error', 'Redis Connect Error', { error: error });
 });
 
+redisClient.select(config.redis.db, function(){})
+
 redisClient.on("connect"
   , function () {
     var redisTestUUID = require('uuid').v4();
@@ -62,7 +64,7 @@ redisClient.on("connect"
  */
 var ubersmith = require('ubersmith');
 
-ubersmith.configure({redisPort: config.redis.port, redisHost: config.redis.host, uberAuth: UberAuth});
+ubersmith.configure({redisPort: config.redis.port, redisHost: config.redis.host, redisDb: config.redis.db, uberAuth: UberAuth});
 
 ubersmith.on('configure.complete', function() {
   if (config.ubersmith.warm_cache === true)

--- a/config/index.js
+++ b/config/index.js
@@ -45,6 +45,7 @@ config.puppetdb.port = process.env.PUPPETDB_PORT || 8080;
 config.redis.uri = process.env.REDIS_URI;
 config.redis.host = process.env.REDIS_HOST || 'localhost';
 config.redis.port = process.env.REDIS_PORT || 6379;
+config.redis.db = process.env.REDIS_DB || 1;
 
 config.http.port = process.env.PORT || 3000;
 config.cookie.secret = 'supersecure';


### PR DESCRIPTION
This commit adds a config.redis.db option for switching the redis DB to something other than 0. It is set to 1 by default here.
