### PR TITLE
Fix alignment issues on /account page

### DIFF
--- a/views/account/index.jade
+++ b/views/account/index.jade
@@ -4,12 +4,12 @@ block head
 block navbar
     include ../_navbar
 block content
-  .container.col-xs-12.col-md-8
+  .container.col-xs-12.col-md-12
     .row
       .page-header
         h1 My Profile
     .row
-      .col-xs-6.col-md-4
+      .col-xs-6.col-md-6
         .panel.panel-default
           if user.displayname
             .panel-heading #{user.displayname}
@@ -29,13 +29,13 @@ block content
                 for photo in user.photos
                   li
                     img(src="#{photo.value}").img-thumbnail
-      .col-xs-6.col-md-4
+      .col-xs-6.col-md-6
         .panel.panel-default
           .panel-heading Primary Email: #{user.email}
           .panel-body
             ul
               for email in user.emails
-                li #{email.value} (#{email.type})
+                li #{email.value}
               else
                 li No additional Addresses
         .panel.panel-default


### PR DESCRIPTION
4.)  Just a small cosmetic thing:  In chrome,  on the "My Profile" page,  it shows a box for "Primary Email:"   The greyed header on that box shows my email just fine.  Below the header, in the white box itself it shows my email address next to a bullet point follwed by ().   The email addy extends outside of the box,  so maybe don't hardcode the size of that box instead making it dynamically sized against hte content going into the box.   Looks like the box size matches the one below it that lists "Account Groups". 
