### PR TITLE
Fixed bug in user authentication

### DIFF
--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -50,12 +50,13 @@ module.exports = function(app, credentials, config, redisClient) {
           user = JSON.parse(userJSON);
         }
         catch (e) {
-          app.locals.logger.log('error', 'uncaught exception');
+          app.locals.logger.log('error', 'uncaught exception', {error: e});
         }
         if (!user) {
-          err = new Error('could not find user');
+          done(err,null);
+        } else {
+          done(err, user);
         }
-        done(err, user);
       }
     });
   };

--- a/src/lib/nock.js
+++ b/src/lib/nock.js
@@ -4,7 +4,8 @@ module.exports = function(config) {
   var nock = require('nock');
 
   nock.recorder.rec({
-    output_objects: true
+    output_objects: false,
+    dont_print: true
   });
 
   nock.disableNetConnect();


### PR DESCRIPTION
When the user is not in cache, or could not be deserialized, treat as unauthenticated and require new loging.
